### PR TITLE
Before Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.0
+
+2021/01/23
+
+- `[New Features]` Implement SubCommands ([#1](https://github.com/yukihirop/gfzs/issues/1))
+  - `gfzs demo`
+  - `gfzs valid`
+- `[Improvement]` Changed to verify the setting before executing the main command ([#1](https://github.com/yukihirop/gfzs/issues/1))
+- `[Fix Bugs]` Error if you press enter twice with Not Found displayed ([#5](https://github.com/yukihirop/gfzs/issues/5))
+
+Please see [milestone](https://github.com/yukihirop/gfzs/milestone/3)
+
 ## 0.1.0
 
 2021/01/22

--- a/gfzs/info.py
+++ b/gfzs/info.py
@@ -2,7 +2,7 @@
 
 __name__ = "gfzs"
 __description__ = "Google Fuzzy Search"
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __copyright__ = "Copyright ©︎ 2021 yukihirop"
 __url__ = "https://github.com/yukihirop/gfzs"
 __author__ = "yukihirop"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gfzs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Google Fuzzy Search"
 authors = ["yukihirop <te108186@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Summary

- bump
- Update CHANGELOG

### TestPypi

https://test.pypi.org/project/gfzs/

```
$ pip install gfzs==0.2.0 --extra-index-url  https://test.pypi.org/simple
Looking in indexes: https://pypi.org/simple, https://test.pypi.org/simple
Collecting gfzs==0.2.0
  Downloading https://test-files.pythonhosted.org/packages/f4/d9/1059957fcbb3934ee21b34fb8ae8a40955963763a2d8d25a09b6e26b1f53/gfzs-0.2.0-py3-none-any.whl (44 kB)
     |████████████████████████████████| 44 kB 3.6 MB/s
Requirement already satisfied: fuzzywuzzy<0.19.0,>=0.18.0 in ./.venv/lib/python3.7/site-packages (from gfzs==0.2.0) (0.18.0)
Requirement already satisfied: python-Levenshtein<0.13.0,>=0.12.1 in ./.venv/lib/python3.7/site-packages (from gfzs==0.2.0) (0.12.1)
Collecting flatten-dict<0.4.0,>=0.3.0
  Using cached flatten_dict-0.3.0-py2.py3-none-any.whl (8.2 kB)
Collecting pathlib2<3.0,>=2.3
  Using cached pathlib2-2.3.5-py2.py3-none-any.whl (18 kB)
Requirement already satisfied: setuptools in ./.venv/lib/python3.7/site-packages (from python-Levenshtein<0.13.0,>=0.12.1->gfzs==0.2.0) (40.8.0)
Collecting six<2.0,>=1.12
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Installing collected packages: six, pathlib2, flatten-dict, gfzs
  Attempting uninstall: gfzs
    Found existing installation: gfzs 0.1.0
    Uninstalling gfzs-0.1.0:
      Successfully uninstalled gfzs-0.1.0
Successfully installed flatten-dict-0.3.0 gfzs-0.2.0 pathlib2-2.3.5 six-1.15.0
```

