### PR TITLE
Paginate and Overhand Error Bugs

### DIFF
--- a/gfzs/utils/text_wrapper.py
+++ b/gfzs/utils/text_wrapper.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+import sys
+import textwrap
+import unicodedata
+from itertools import groupby
+
+# copy from http://www.freia.jp/taka/blog/python-textwrap-with-japanese/index.html
+
+# copy from docutils
+east_asian_widths = {
+    "W": 2,  # Wide
+    "F": 2,  # Full-width (wide)
+    "Na": 1,  # Narrow
+    "H": 1,  # Half-width (narrow)
+    "N": 1,  # Neutral (not East Asian, treated as narrow)
+    "A": 1,
+}  # Ambiguous (s/b wide in East Asian context,
+# narrow otherwise, but that doesn't work)
+
+# copy from docutils
+def column_width(text):
+    """Return the column width of text.
+
+    Correct ``len(text)`` for wide East Asian and combining Unicode chars.
+    """
+    if isinstance(text, str) and sys.version_info < (3, 0):
+        return len(text)
+    combining_correction = sum([-1 for c in text if unicodedata.combining(c)])
+    try:
+        width = sum([east_asian_widths[unicodedata.east_asian_width(c)] for c in text])
+    except AttributeError:  # east_asian_width() New in version 2.4.
+        width = len(text)
+    return width + combining_correction
+
+
+class TextWrapper(textwrap.TextWrapper):
+    """Custom subclass that uses a different word splitter."""
+
+    def _wrap_chunks(self, chunks):
+        """_wrap_chunks(chunks : [string]) -> [string]
+
+        Original _wrap_chunks use len() to calculate width.
+        This method respect to wide/fullwidth characters for width adjustment.
+        """
+        lines = []
+        if self.width <= 0:
+            raise ValueError("invalid width %r (must be > 0)" % self.width)
+
+        chunks.reverse()
+
+        while chunks:
+            cur_line = []
+            cur_len = 0
+
+            if lines:
+                indent = self.subsequent_indent
+            else:
+                indent = self.initial_indent
+
+            width = self.width - column_width(indent)
+
+            if self.drop_whitespace and chunks[-1].strip() == "" and lines:
+                del chunks[-1]
+
+            while chunks:
+                l = column_width(chunks[-1])
+
+                if cur_len + l <= width:
+                    cur_line.append(chunks.pop())
+                    cur_len += l
+
+                else:
+                    break
+
+            if chunks and column_width(chunks[-1]) > width:
+                self._handle_long_word(chunks, cur_line, cur_len, width)
+
+            if self.drop_whitespace and cur_line and cur_line[-1].strip() == "":
+                del cur_line[-1]
+
+            if cur_line:
+                lines.append(indent + "".join(cur_line))
+
+        return lines
+
+    def _break_word(self, word, space_left):
+        """_break_word(word : string, space_left : int) -> (string, string)
+
+        Break line by unicode width instead of len(word).
+        """
+        total = 0
+        for i, c in enumerate(word):
+            total += column_width(c)
+            if total > space_left:
+                return word[: i - 1], word[i - 1 :]
+        return word, ""
+
+    def _split(self, text):
+        """_split(text : string) -> [string]
+
+        Override original method that only split by 'wordsep_re'.
+        This '_split' split wide-characters into chunk by one character.
+        """
+        split = lambda t: textwrap.TextWrapper._split(self, t)
+        chunks = []
+        for chunk in split(text):
+            for w, g in groupby(chunk, column_width):
+                if w == 1:
+                    chunks.extend(split("".join(g)))
+                else:
+                    chunks.extend(list(g))
+        return chunks
+
+    def _handle_long_word(self, reversed_chunks, cur_line, cur_len, width):
+        """_handle_long_word(chunks : [string],
+                             cur_line : [string],
+                             cur_len : int, width : int)
+
+        Override original method for using self._break_word() instead of slice.
+        """
+        space_left = max(width - cur_len, 1)
+        if self.break_long_words:
+            l, r = self._break_word(reversed_chunks[-1], space_left)
+            cur_line.append(l)
+            reversed_chunks[-1] = r
+
+        elif not cur_line:
+            cur_line.append(reversed_chunks.pop())

--- a/gfzs/views/search_result.py
+++ b/gfzs/views/search_result.py
@@ -2,7 +2,6 @@
 
 import curses
 import unicodedata
-import textwrap
 import math
 import os, sys
 
@@ -15,6 +14,7 @@ try:
         sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
         from utils.markup import Markup
         from utils.multibyte import Multibyte
+        from utils.text_wrapper import TextWrapper
         import utils.logger as logger
 
         from not_found import NotFound
@@ -28,6 +28,7 @@ try:
     else:
         from gfzs.utils.markup import Markup
         from gfzs.utils.multibyte import Multibyte
+        from gfzs.utils.text_wrapper import TextWrapper
         import gfzs.utils.logger as logger
 
         from gfzs.views.not_found import NotFound
@@ -41,6 +42,7 @@ except ModuleNotFoundError:
     sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname("../"))))
     from utils.markup import Markup
     from utils.multibyte import Multibyte
+    from utils.text_wrapper import TextWrapper
     import utils.logger as logger
 
     from views.not_found import NotFound
@@ -285,8 +287,9 @@ class SearchResult(Base):
             i += self.TEXTBOX_HEIGHT
 
         # When all are displayed as multi-byte character strings
-        gap = 6  # 4 = 1 (Frame border) + 3(padding) + 2(margin)
-        abstract_line_len = self.parent_width // 2 - gap
+        gap = 7  # 4 = 1 (Frame border) + 3(padding) + 3(margin)
+        abstract_line_len = self.parent_width - 2 * gap
+        text_wrapper = TextWrapper(width=abstract_line_len)
         can_write_fn = lambda y: (4 + y) <= (self.TEXTBOX_HEIGHT - 1)
 
         for k in range(len(textboxes)):
@@ -301,7 +304,8 @@ class SearchResult(Base):
             )
             textboxes[k].addstr(2, 6, title, self.colors["title"])
             textboxes[k].addstr(3, 6, url, self.colors["url"])
-            lines = textwrap.wrap(abstract, abstract_line_len)
+
+            lines = text_wrapper.wrap(abstract)
             for l in range(len(lines)):
                 if can_write_fn(l):
                     textboxes[k].addstr(4 + l, 6, lines[l], self.colors["abstract"])

--- a/gfzs/views/search_result.py
+++ b/gfzs/views/search_result.py
@@ -287,6 +287,8 @@ class SearchResult(Base):
         # When all are displayed as multi-byte character strings
         gap = 6  # 4 = 1 (Frame border) + 3(padding) + 2(margin)
         abstract_line_len = self.parent_width // 2 - gap
+        can_write_fn = lambda y: (4 + y) <= (self.TEXTBOX_HEIGHT - 1)
+
         for k in range(len(textboxes)):
             textboxes[k].box()
 
@@ -301,7 +303,8 @@ class SearchResult(Base):
             textboxes[k].addstr(3, 6, url, self.colors["url"])
             lines = textwrap.wrap(abstract, abstract_line_len)
             for l in range(len(lines)):
-                textboxes[k].addstr(4 + l, 6, lines[l], self.colors["abstract"])
+                if can_write_fn(l):
+                    textboxes[k].addstr(4 + l, 6, lines[l], self.colors["abstract"])
 
             # Markup Search Query for title
             markup_data = self.markup.parse(title, self.model.query)
@@ -327,9 +330,13 @@ class SearchResult(Base):
                             match_text
                         )
                         if offset_x + 6 + match_text_byte_len <= self.parent_width - 1:
-                            textboxes[k].addstr(
-                                4 + l, 6 + offset_x, match_text, color | curses.A_BOLD
-                            )
+                            if can_write_fn(l):
+                                textboxes[k].addstr(
+                                    4 + l,
+                                    6 + offset_x,
+                                    match_text,
+                                    color | curses.A_BOLD,
+                                )
                         # Wrap display
                         else:
                             match_text_before = match_text[
@@ -339,17 +346,18 @@ class SearchResult(Base):
                                 match_text_before
                             )
                             gap = 6  # 4 = 1 (Frame border) + 3(padding) + 2(margin)
-                            textboxes[k].addstr(
-                                4 + l,
-                                self.parent_width - byte_len - gap,
-                                match_text_before,
-                                color,
-                            )
+                            if can_write_fn(l + 1):
+                                textboxes[k].addstr(
+                                    4 + l,
+                                    self.parent_width - byte_len - gap,
+                                    match_text_before,
+                                    color,
+                                )
 
-                            match_text_after = match_text[
-                                (self.parent_width - offset_x) :
-                            ]
-                            textboxes[k].addstr(5 + l, 6, match_text_after, color)
+                                match_text_after = match_text[
+                                    (self.parent_width - offset_x) :
+                                ]
+                                textboxes[k].addstr(5 + l, 6, match_text_after, color)
 
         return textboxes
 

--- a/gfzs/views/search_result.py
+++ b/gfzs/views/search_result.py
@@ -458,10 +458,10 @@ class SearchResult(Base):
         elif textboxes_len > 1 and user_input == curses.KEY_UP:
             logger.debug("[SearchResult] handle key in loop with 'KEY_UP'")
             self.helper.up(textboxes_len)
-        elif textboxes_len > per_page + 1 and user_input == curses.KEY_RIGHT:
+        elif textboxes_len >= per_page + 1 and user_input == curses.KEY_RIGHT:
             logger.debug("[SearchResult] handle key in loop with 'KEY_RIGHT'")
             self.helper.next_page(textboxes_len)
-        elif textboxes_len > per_page + 1 and user_input == curses.KEY_LEFT:
+        elif textboxes_len >= per_page + 1 and user_input == curses.KEY_LEFT:
             logger.debug("[SearchResult] handle key in loop with 'KEY_LEFT'")
             self.helper.prev_page(textboxes_len)
         elif user_input == curses.KEY_RESIZE:


### PR DESCRIPTION
### Summary

Fix #16 

### SS

#### before(demo)

![image](https://user-images.githubusercontent.com/11146767/106584907-152b8d00-658a-11eb-8d50-75ed5a43c693.png)


#### after(demo)

![image](https://user-images.githubusercontent.com/11146767/106585054-4441fe80-658a-11eb-8cee-6926053be7a8.png)


#### before(demo/resize)

```
$ bin/gfzs demo
Error: addwstr() returned ERR
```

#### after(demo/resize)

![image](https://user-images.githubusercontent.com/11146767/106584298-5ec7a800-6589-11eb-9082-0d8fd060b192.png)

### Test

Currently there are no tests.  
Instead, the operation is guaranteed by executing the following command and actually checking the operation.

- [x] python3 gfzs/views/not_found.py
- [x] python3 gfzs/views/paging.py
- [x] python3 gfzs/views/footer.py
- [x] python3 gfzs/views/header.py
- [x] python3 gfzs/views/search_result.py
- [x] python3 gfzs/utils/markup.py
- [x] python3 gfzs/utils/color.py
- [x] python3 gfzs/runtime/config.py
- [x] python3 gfzs/cmd/init.py
- [x] python3 gfzs/cmd/edit.py
- [x] python3 gfzs/cmd/demo.py
- [x] python3 gfzs/cmd/valid.py
- [x] python3 gfzs/controller.py
- [x] python3 gfzs/model.py
- [x] cat fixtures/rust.json | bin/gfzs -s 20 -l 0 -p ./tmp/gfzs.log
- [x] cat fixtures/rust.json | python3 -m gfzs -s 40 -l 0 -p ./tmp/gfzs.log
- [x] bin/gfzs -l 0 -p ./tmp/gfzs.log init
- [x] bin/gfzs -l 0 -p ./tmp/gfzs.log edit
- [x] bin/gfzs -l 0 -p ./tmp/gfzs.log demo
- [x] bin/gfzs -l 0 -p ./tmp/gfzs.log valid
- [x] black gfzs/**/*.py
